### PR TITLE
fix incorrect obstacle definition

### DIFF
--- a/conversion.py
+++ b/conversion.py
@@ -5,11 +5,11 @@ import numpy as np
 from pathlib import Path
 from math import *
 
-def get_polytope(point, epsilon):
-    A_rect = np.array([[-1,0,-(point[0]-epsilon[0])],
-				       [1,0,point[0]+epsilon[0]],
-				       [0,-1,-(point[1]-epsilon[1])],
-				       [0,1,point[1]+epsilon[1]]])
+def get_polytope(point, b):
+    A_rect = np.array([[-1,0,-(point[0]-b[0])],
+				       [1,0,point[0]+b[0]],
+				       [0,-1,-(point[1]-b[1])],
+				       [0,1,point[1]+b[1]]])
     return A_rect.tolist()
 
 def format_to_s2m2(env,env_folder,cfg_file):
@@ -59,11 +59,13 @@ def format_to_s2m2(env,env_folder,cfg_file):
         new_format["starts"].append(robots[i]["start"][:2]) # position just, no orientation
     for j in range(len(obstacles)):
         new_format["obstacles"].append(get_polytope(obstacles[j]["center"], np.array(obstacles[j]["size"]) / 2))
+   
     # add four obstacle to have the workspace limit
-    new_format["obstacles"].append(get_polytope([x_min-radius,(y_max-y_min)/2], [0.2,y_max-y_min]))
-    new_format["obstacles"].append(get_polytope([x_max+radius,(y_max-y_min)/2], [0.2,y_max-y_min]))
-    new_format["obstacles"].append(get_polytope([(x_max-x_min)/2,y_min-radius], [x_max-x_min,0.2]))
-    new_format["obstacles"].append(get_polytope([(x_max-x_min)/2,y_max+radius], [x_max-x_min,0.2]))
+    
+    new_format["obstacles"].append(get_polytope([x_min-radius-0.1,(y_max-y_min)/2], [0.2,(y_max-y_min)/2]))
+    new_format["obstacles"].append(get_polytope([x_max+radius+0.1,(y_max-y_min)/2], [0.2,(y_max-y_min)/2]))
+    new_format["obstacles"].append(get_polytope([(x_max-x_min)/2,y_min-radius-0.1], [(x_max-x_min)/2,0.2]))
+    new_format["obstacles"].append(get_polytope([(x_max-x_min)/2,y_max+radius+0.1], [(x_max-x_min)/2,0.2]))
     
     with open(Path(env_folder) / env_name / 'problem.yaml', 'w') as outfile:
         yaml.dump(new_format, outfile)   

--- a/viz/util.py
+++ b/viz/util.py
@@ -15,18 +15,23 @@ def plot_env(map_limits, Obstacles):
         # Configure
         xmin, xmax = map_limits[0]
         ymin, ymax = map_limits[1]
-        plt.xlim(xmin-2, xmax+2)
-        plt.ylim(ymin-2, ymax+2)
+        plt.xlim(xmin-1, xmax+1)
+        plt.ylim(ymin-1, ymax+1)
         # # viz obstacles
         for A, b in Obstacles:
-            poly = Polygon(ppm.duality.compute_polytope_vertices(A, b))
-            x, y = poly.exterior.xy
+            # poly = Polygon(ppm.duality.compute_polytope_vertices(A, b))
+            # x, y = poly.exterior.xy
+            x_min = -b[0]
+            x_max = b[1]
+            y_min = -b[2]
+            y_max = b[3]
+            x = [x_min,x_min,x_max,x_max]
+            y = [y_min,y_max,y_max,y_min]
             plt.fill(x, y, facecolor='r', alpha=0.3)
         ax = fig.gca()
         plt.gca().set_aspect('equal', adjustable='box')
-        plt.axis('off')
-        ax.get_xaxis().set_visible(False)
-        ax.get_yaxis().set_visible(False)
+        ax.get_xaxis().set_visible(True)
+        ax.get_yaxis().set_visible(True)
         plt.margins(0, 0)
 
     elif len(map_limits) == 3:


### PR DESCRIPTION
Incorrect obstacle definition is solved (issue71 in db-cbs). The problem was the incorrect sequence of vertices that was computed with ppm.duality.compute_polytope_vertices(A, b), Pypoman python library. For some cases it gives the wrong order of vertices. Now, I do it with simple mathematics. Checked with alcove_unicycle_sphere example. Axis also visible now for the video. 

Workspace limiting obstacles are also correct now. 